### PR TITLE
Create lambda that send image to GCP

### DIFF
--- a/resources/functions/image-process.yaml
+++ b/resources/functions/image-process.yaml
@@ -1,0 +1,64 @@
+apiVersion: serverless.kyma-project.io/v1alpha1
+kind: Function
+metadata:
+  name: image-process
+spec:
+  deps: |-
+    {
+      "name": "image-process",
+      "version": "1.0.0",
+      "dependencies": {
+        "@google-cloud/vision":"2.3.8"
+      }
+    }
+  env:
+    - name: GCP_EMAIL
+      valueFrom:
+        secretKeyRef:
+          key: GCP_EMAIL
+          name: kyma-showcase-secret
+    - name: GCP_API_KEY
+      valueFrom:
+        secretKeyRef:
+          key: GCP_API_KEY
+          name: kyma-showcase-secret
+  runtime: nodejs14
+  source: |
+    module.exports = {
+      main: async function (event, context) {
+        // const base64 = getBase64();
+
+        // if (!base64) {
+        //   return null;
+        // }
+
+        const base64 =
+          'iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAACxQAAAsUBidZ/7wAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAeNSURBVHic7Z1riFVVFMd/46SmqJljTlZoOqaJRg+jErUmNaqB7CURVJ8sJNLogQQVUX0J+lCRhoQplH6pSGY0yCdlKpQhEuYrtdR8ZJqPyUyd0enDcnRG7zn7nHv3PsdxrR8s0Nl377Xu2f9z7z57rXNuGf7pDYwDaoAhQC+gawA/GjgK7Ac2AouBWmBLrhHFMAxYCJwEmsyC2U/AvQnnJBO6A3OAU+R/cDTZEqBvgvkJygBgHfkfDK22H6h2TVIohgIHYoIzy8aOI+utTKkANpcYuJk/q0dOyMxYHOBNmJVmm4FOcZNWiPK0HYAHgVeL6GeEpQdwBFgR0kk5yRd9dch+QCVQFjKoi5gKYDQwC2jEfcwPnu4TjLEJgqhHJt7wy63AH7iP//Mhg5jqcN4AjAkZgHIGIWd53BwsDRnAdofzqSGdGwBMwn0Sdg/huMLhuAmoCuHYaEVH5Gs2bh5GJR2sXQrHfRzt24CtKcYziuM4sNzxGtdcnSGNALo42nenGMsojV2O9sTZ1zQCcO0ZnEgxllEarmOdeH8njQCMixATgHJMAMoxASjHBKAcE4ByTADKMQEoxwSgHBOAckwAyjEBKMcEoBwTgHJMAMoxASjHBKAcE4ByTADKMQEoxwSgHBOAckwAyjEBKMcEoBwTgHJMAMoxASjHBKAcE4ByTADKMQEoxwSgHBOAckwAyjEBKMcEoBwTgHJMAMoxASjHBKAcE4ByTADKMQEoxwSgHBOAckwAyjEBKMcEoBwTgHJMAMoxASjHBKAcE4ByTADKMQEoxwSgHBOAci7JO4AUdAGGA+2BVcD+BH3aAbcA1wJlBdrrgb+AHcDfXqJszTVAP6AX8SdbI7AJWB8gBm9UE/+T5d8G9P0IsK+Fr2PA644+/YGVuH/yvgk4BawF3gcGlhhrR+AF4OeEvlvaN0BFAh/THOM8V+J7KEi1w2koAQxDfiy5kM8nIvpcCqxzxBtlJ4EvgcoiY/2tSL/NVpvAjyoBLIzxuT2iz9OOWJPYXmB0ijjvAf714LcJuMPhy5sA2sIicGhMWx/gsgJ/H+LBby9gPrLucDEQ+ALo7MEv+Ik/EW1BAO0d7R2K6JOUzkAdcLnjdR8A3T35BFmYZkJbEEDeXAG8GdN+G3C/R397gKUex4vFBJCMiUC3iLZHPfo5DDwOHPU4ZixtaR/AJ2uALcikDkbWEnF0RM7yzwu0jXD0PQh8h1zrR9EIbABmArsd43lFqwBmAh+1+P9dyCKuV0yf4RQWQG+Hr3HAilTRZYh9BQjLgLccr7kq4u9dHf02pQ8nO0wAZ/nd0R61BmjTmADOcp+jfW8mUWSM1jVAM92QjaankJV+HFG7jm0arQKYdtrSsCBEIHmjVQBp2Qn84GmszsCzwE3I5SWcTQd/Auzy5CcReQmgL3AjcAD4EWjIKY6kvIakjEulH5Lcui6i/SWgBkljZ0LWi8AOwHtIyrQOWI5syIzKOI40LAVmexprFtGTD7ImmY2/pJKTrAXwNvDiOX77APOQ6pkLjbXAeCTFWioDkJS6i37AGA/+EpGlACqAlyPauiNVNBcSXyETdsjTeD1SvDazkyFLAQwifs1xQ8TfC9XytcTH2dmS1chZPx5Zo/hiE3A84Wszm5csF4GF8vau9jIKF3w000RpZ+hhZINnB/A9sBh/q/1CvqZzgX3SZSkAV4qz0MJnMPHFHYeIz7JFMYnWyaCsmIIIfSJQnoP/88jyK8BVxt0fKeZsyQRHn63Fh+ONE472Li3+3YjU680IF046svwE2IMcrKivgp5IDd5cpF7/TuAZx5jLvEVXPH8CV8e0z0DSzy0/qfoFjSgFWQrgP2TTJ+6af+xpS8qikiLyw3qkHDyKMWR4WZeWrPcB5nscawOyaMuburwDKIWsBfAxUiLlg3fwfwlYDPOQ3cw2SdYCqEf21UullvjtWZcwfOzrN9MAvOJxPPAbXyx5FIRMR/bEi2UNcudPHK6M2s4S/BdiLvCux/F8x+eFavzdGtYOqcE75RjzXFtAstKsKmTXrdAYuwmTbCkD3iD9eyomvovm3sBhyMf5ScfYG4HHUo79JOffq3cIubwMyQikCriYyU8anzcB5F0Qshp4CEmU3I3UCPREkkPNW7RLkKxcWuYgl50TkOTKJrKpu18JjERyHzXINX8l8TmN3O4LSEM1/j8BjOJQdXewERATgHJMAMoxASjHBKCcNAI46Wh3VfwY/nAda9dcnSGNAI442qPunjX84yoa/SeE0wrcO1lVIRwbreiIJNXi5mFkKOfbHI7zqLPTxmTi5+AEfh9Y1YoPHc4bkOflGWG4HskXxM3BkpABjHE4b0I+nh4OGYRSbkfSxK7jPzlkEOXALwmCaAK+RoRwJXa5WSw9kRrJT5GEkeuYHyTdHUhF8UCCQMzysSkx8+aVuOf3muVjvwKd4ibNJz2AzYHfkFlyqyfD5ws3MwT5kYW837x2O4YUnuRCFcU/l9+sdNtHsmcOBOUy4DPcdX1mfm0R7kfcZsrNSNWuCSGsrcLjZpvr4QvF0Bu5VKxB1gmVuB+nahTmKHJXdfNtcLV4viP6f6QoYCqoxBwXAAAAAElFTkSuQmCC';
+
+        try {
+          const vision = require('@google-cloud/vision');
+          const options = {
+            credentials: {
+              client_email: process.env.GCP_EMAIL,
+              private_key: process.env.GCP_API_KEY.replace(/\\n/gm, '\n'),
+            },
+          };
+
+          const client = new vision.ImageAnnotatorClient(options);
+          const request = {
+            image: {
+              content: Buffer.from(base64, 'base64'),
+            },
+          };
+
+          const [result] = await client.labelDetection(request);
+          const resultLabels = result.labelAnnotations;
+          const labels = resultLabels.map(label => label.description);
+          console.log(labels);
+          return { labels: labels };
+        } catch (err) {
+          console.log(err);
+          return null;
+        }
+      },
+    };


### PR DESCRIPTION
**Description**
Lambda sends an image in base64 to GCP for processing and receives GCP response with detected labels.

**Changes**
- add .yaml file with lambda functionality configuration

**Additional informations**
- first lines are temporary, to do in future PR
- we need to add a replacement to properly use API key secret [solution](https://github.com/auth0/node-jsonwebtoken/issues/642) 

Related issue #60 