### PR TITLE
Checking if content exists when posting to database

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/gabriel-vasile/mimetype v1.3.1
+	bou.ke/monkey v1.0.2
 	github.com/go-redis/redis/v8 v8.11.0
 	github.com/go-redis/redismock/v8 v8.0.6
 	github.com/gorilla/mux v1.8.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,3 +1,5 @@
+bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
+bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -73,6 +73,25 @@ func accessControl(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+////requestContent check if request body contains image saved in base64
+//func requestContent(w http.ResponseWriter, r *http.Request) error {
+//	bodyContent, err := ioutil.ReadAll(r.Body)
+//
+//	if err != nil {
+//		err := errors.New("requestContent: failed to read body content")
+//		log.Error(err)
+//		return err
+//	}
+//	_, err = base64.StdEncoding.DecodeString(string(bodyContent))
+//
+//	if err != nil {
+//		err := errors.New("requestContent: body content is not an image")
+//		log.Error(err)
+//		return err
+//	}
+//	return nil
+//}
+
 // Get processes a request and passes request ID to the GetFromDB function, returns the value of the given ID.
 func (h Handler) Get(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
@@ -203,6 +222,7 @@ func (h Handler) Create(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
+
 	accessControl(w, r)
 	var img model.Image
 
@@ -294,6 +314,15 @@ func (h Handler) Create(w http.ResponseWriter, r *http.Request) {
 	img.ID = id
 	imgTime := time.Now()
 	img.Time = imgTime.Format(time.RFC3339)
+
+	_, err = base64.StdEncoding.DecodeString(img.Content)
+
+	if err != nil {
+		err := errors.New("CREATE handler: content is not an image" + err.Error())
+		log.Error(err)
+		http.Error(w, err.Error(), http.StatusNotAcceptable)
+		return
+	}
 
 	jsonImg, err := json.Marshal(img)
 	if err != nil {

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -312,10 +312,13 @@ func (h Handler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	img.ID = id
+
 	imgTime := time.Now()
 	img.Time = imgTime.Format(time.RFC3339)
 
-	_, err = base64.StdEncoding.DecodeString(img.Content)
+	m1 := regexp.MustCompile("data:.*?base64,")
+	contentBase64 := m1.ReplaceAllString(img.Content, "")
+	_, err = base64.StdEncoding.DecodeString(contentBase64)
 
 	if err != nil {
 		err := errors.New("CREATE handler: content is not an image" + err.Error())
@@ -327,6 +330,13 @@ func (h Handler) Create(w http.ResponseWriter, r *http.Request) {
 	jsonImg, err := json.Marshal(img)
 	if err != nil {
 		err = errors.New("CREATE handler: failed to convert json into marshal: " + err.Error())
+		log.Error(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if img.Content == "" {
+		err := errors.New("CREATE handler: content is empty")
 		log.Error(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -73,25 +73,6 @@ func accessControl(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-////requestContent check if request body contains image saved in base64
-//func requestContent(w http.ResponseWriter, r *http.Request) error {
-//	bodyContent, err := ioutil.ReadAll(r.Body)
-//
-//	if err != nil {
-//		err := errors.New("requestContent: failed to read body content")
-//		log.Error(err)
-//		return err
-//	}
-//	_, err = base64.StdEncoding.DecodeString(string(bodyContent))
-//
-//	if err != nil {
-//		err := errors.New("requestContent: body content is not an image")
-//		log.Error(err)
-//		return err
-//	}
-//	return nil
-//}
-
 // Get processes a request and passes request ID to the GetFromDB function, returns the value of the given ID.
 func (h Handler) Get(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)

--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -370,6 +370,7 @@ func TestCreate(t *testing.T) {
 			assert.Equal(t, tt.statusCode, recorder.Code)
 		})
 	}
+
 	t.Run("should return 406 status code when getting image from url failed", func(t *testing.T) {
 
 		//given


### PR DESCRIPTION
**Description**
Fixed bug when the user sends POST request with the invalid content body. API is no longer processing that request.

**Changes**
- API is no longer processing requests with invalid content body

Resolve #89 

